### PR TITLE
Update BoardV1.java

### DIFF
--- a/src/main/java/com/google/devrel/samples/ttt/spi/BoardV1.java
+++ b/src/main/java/com/google/devrel/samples/ttt/spi/BoardV1.java
@@ -28,7 +28,9 @@ import com.google.devrel.samples.ttt.Board;
  */
 @Api(
     name = "tictactoe",
-    version = "v1"
+    version = "v1",
+    clientIds = {Ids.WEB_CLIENT_ID, Ids.ANDROID_CLIENT_ID, Ids.IOS_CLIENT_ID},
+    audiences = {Ids.ANDROID_AUDIENCE}
 )
 public class BoardV1 {
   public static final char X = 'X';


### PR DESCRIPTION
To make API-wide configuration matches between classes.
Otherwise I see the following error when I run "mvn clean install" 

[ERROR]
com.google.api.server.spi.config.validation.InconsistentApiConfigurationException: tictactoe: API-wide configuration does not match between the classes com.google.devrel.samples.ttt.spi.ScoresV1 and com.google.devrel.samples.ttt.spi.BoardV1. All API classes with the same API name and version must have the exact same API-wide configuration.
    at com.google.api.server.spi.config.validation.ApiConfigValidator.validate(ApiConfigValidator.java:55)
    at com.google.api.server.spi.tools.AnnotationApiConfigGenerator.generateConfigObjects(AnnotationApiConfigGenerator.java:175)
    at com.google.api.server.spi.tools.AnnotationApiConfigGenerator.generateConfig(AnnotationApiConfigGenerator.java:104)
    at com.google.api.server.spi.tools.GenApiConfigAction.genApiConfig(GenApiConfigAction.java:81)
    at com.google.api.server.spi.tools.GenApiConfigAction.execute(GenApiConfigAction.java:53)
    at com.google.api.server.spi.tools.EndpointsTool.execute(EndpointsTool.java:67)
    at com.google.api.server.spi.tools.EndpointsTool.main(EndpointsTool.java:93)
    at com.google.appengine.endpoints.EndpointsMojo.executeEndpointsCommand(EndpointsMojo.java:91)
    at com.google.appengine.endpoints.EndpointsGetDiscoveryDoc.execute(EndpointsGetDiscoveryDoc.java:49)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:106)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:318)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:153)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:555)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:414)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:357)
